### PR TITLE
Add npm setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# God
+# Dieu du Dimanche
+
+Ce dépôt contient le prototype du jeu web **Dieu du Dimanche**. Le jeu se lance dans un navigateur et peut être exécuté localement via un petit serveur HTTP.
+
+## Lancer le jeu
+
+1. Assurez-vous d'avoir Node.js et npm installés sur votre machine.
+2. Clonez ce dépôt puis exécutez le script `setup.sh` :
+
+```bash
+./setup.sh
+```
+
+Ce script installe les dépendances npm et lance un serveur local grâce au paquet `http-server`. Par défaut, le jeu est accessible sur `http://localhost:8080`.
+
+Vous pouvez également lancer manuellement les commandes suivantes :
+
+```bash
+npm install
+npm start
+```
+
+Le jeu se trouve dans le dossier `dieu_du_dimanche/` et ne nécessite aucune étape de compilation.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "dieu-du-dimanche",
+  "version": "1.0.0",
+  "description": "Prototype de jeu humoristique 'Dieu du Dimanche'",
+  "scripts": {
+    "start": "http-server dieu_du_dimanche"
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1"
+  }
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Script d'installation et de lancement du jeu Dieu du Dimanche
+# Utilisation: ./setup.sh
+
+# Installation des dépendances npm
+npm install
+
+# Lancement du serveur local
+npm start


### PR DESCRIPTION
## Summary
- update README with npm launch instructions
- add `package.json` with `http-server`
- add helper script `setup.sh`

## Testing
- `npm install` *(fails: connect EHOSTUNREACH)*
- `npm test` *(fails: Missing script `test`)*